### PR TITLE
Fixed links in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ This repository holds all the ipython source and data for the "Learning scikit-l
 
 * [Chapter 1 (2nd ed.) - A Gentle Introduction to Machine Learning with Python and Scikit-learn](http://nbviewer.ipython.org/github/gmonce/scikit-learn-book/blob/master/Chapter%201%20%282nd%20ed.%29%20-%20A%20Gentle%20Introduction%20to%20Machine%20Learning%20with%20Python%20and%20Scikit-learn.ipynb) - Extended version, including classification, clustering and regression!. Warning:Python 3
 
-* [Chapter 2 - Supervised Learning - Image Recognition with Support Vector Machines] (http://nbviewer.ipython.org/github/gmonce/scikit-learn-book/blob/master/Chapter%202%20-%20Supervised%20Learning%20-%20Image%20Recognition%20with%20Support%20Vector%20Machines.ipynb)
+* [Chapter 2 - Supervised Learning - Image Recognition with Support Vector Machines](http://nbviewer.ipython.org/github/gmonce/scikit-learn-book/blob/master/Chapter%202%20-%20Supervised%20Learning%20-%20Image%20Recognition%20with%20Support%20Vector%20Machines.ipynb)
 
 * [Chapter 2 - Supervised Learning - Regression](http://nbviewer.ipython.org/github/gmonce/scikit-learn-book/blob/master/Chapter%202%20-%20Supervised%20Learning%20-%20Regression.ipynb)
 
-* [Chapter 2 - Supervised Learning - Text Classification with Naive Bayes] (http://nbviewer.ipython.org/github/gmonce/scikit-learn-book/blob/master/Chapter%202%20-%20Supervised%20Learning%20-%20Text%20Classification%20with%20Naive%20Bayes.ipynb)
+* [Chapter 2 - Supervised Learning - Text Classification with Naive Bayes](http://nbviewer.ipython.org/github/gmonce/scikit-learn-book/blob/master/Chapter%202%20-%20Supervised%20Learning%20-%20Text%20Classification%20with%20Naive%20Bayes.ipynb)
 
-* [Chapter 2 - Supervised Learning - Explaining Titanic Hypothesis with Decision Trees]
-(http://nbviewer.ipython.org/github/gmonce/scikit-learn-book/blob/master/Chapter%202%20-%20Supervised%20learning%20-%20Explaining%20Titanic%20Hypothesis%20with%20Decision%20Trees.ipynb)
+* [Chapter 2 - Supervised Learning - Explaining Titanic Hypothesis with Decision Trees](http://nbviewer.ipython.org/github/gmonce/scikit-learn-book/blob/master/Chapter%202%20-%20Supervised%20learning%20-%20Explaining%20Titanic%20Hypothesis%20with%20Decision%20Trees.ipynb)
 
 * [Chapter 3 - Unsupervised Learning - Clustering Handwritten Digits](http://nbviewer.ipython.org/github/gmonce/scikit-learn-book/blob/master/Chapter%203%20-%20Unsupervised%20Learning%20-%20Clustering%20Handwritten%20Digits.ipynb)
 


### PR DESCRIPTION
Some link markdown was wrong and wasn't displaying correctly due to spaces.